### PR TITLE
docs: add release documentation and update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,16 @@
 name: Release Obsidian plugin
 
 on:
-    push:
-        tags:
-            - "*"
+    workflow_dispatch:
+        inputs:
+            version:
+                description: "Version bump type"
+                required: true
+                type: choice
+                options:
+                    - patch
+                    - minor
+                    - major
 
 jobs:
     build:
@@ -25,13 +32,27 @@ jobs:
                   npm install
                   npm run build
 
+            - name: Configure git
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            - name: Bump version
+              env:
+                  VERSION: ${{ github.event.inputs.version }}
+              run: |
+                  tag=$(npm version "$VERSION")
+                  echo "TAG=$tag" >> $GITHUB_ENV
+
+            - name: Push commit and tag
+              run: git push && git push --tags
+
             - name: Create release
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  tag="${GITHUB_REF#refs/tags/}"
-
-                  gh release create "$tag" \
-                    --title="$tag" \
+                  gh release create "$TAG" \
+                    --title="$TAG" \
+                    --generate-notes \
                     --draft \
                     main.js manifest.json styles.css

--- a/README.md
+++ b/README.md
@@ -9,8 +9,16 @@ Converts your Markdown files to BBCode, for pasting into forums
 3. Link this directory to the test vault's `.obsidian/plugins` directory: `ln -s `pwd` Test\ Vault/.obsidian/plugins/obsidian-bbcode`.
 4. Build with `npm run dev`
 5. When you're all done, commit your changes.
-6. Version your changes with `npm version [major|minor|patch]`
-7. Push the new version with `git push --tags`
+
+#### Releasing a New Version
+
+Releases are handled by the **Release Obsidian plugin** GitHub Actions workflow. To cut a release:
+
+1. Go to **Actions → Release Obsidian plugin → Run workflow** on GitHub.
+2. Choose a bump type from the dropdown: `patch`, `minor`, or `major`.
+3. Click **Run workflow**.
+
+The workflow will run `npm version`, push the commit and tag, and create a draft GitHub release with the built assets attached. Publish the draft when you're ready.
 
 #### Usage
 


### PR DESCRIPTION
Add comprehensive release instructions to README and refactor the GitHub Actions release workflow to use workflow_dispatch instead of git tags, allowing manual control over version bumping.